### PR TITLE
Add proxy route for Toggl-Asana sync

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,6 +14,7 @@ type PROD_ENV = {
   PUBLIC_NOTION_SECRET: string;
   TODOIST_AUTO_LABEL_SECRET: string;
   TODOIST_CLIENT_SECRET: string;
+  TOGGL_ASANA_SCRIPT_URL: string;
 };
 
 type STAGE_ENV = {
@@ -22,6 +23,7 @@ type STAGE_ENV = {
   OPENAI_API_KEY: string;
   PUBLIC_NOTION_SECRET: string;
   TODOIST_CLIENT_SECRET: string;
+  TOGGL_ASANA_SCRIPT_URL: string;
 };
 
 type Runtime = import("@astrojs/cloudflare").DirectoryRuntime<ENV>;

--- a/src/pages/workers/toggl-asana-sync.ts
+++ b/src/pages/workers/toggl-asana-sync.ts
@@ -1,0 +1,50 @@
+export const prerender = false;
+
+export async function POST({ request }: { request: Request }) {
+  const GOOGLE_APPS_SCRIPT_URL = import.meta.env.TOGGL_ASANA_SCRIPT_URL || "https://script.google.com/macros/s/AKfycbxb0iSucSMseYnijg1EZOuC3eS0STz7CSHAPKy6kZk4cBzuZMYIZOgvCiFCA1AMBZkj/exec";
+  
+  try {
+    const body = await request.text();
+    const headers = new Headers();
+    
+    for (const [key, value] of request.headers.entries()) {
+      if (key.toLowerCase() !== 'host' && key.toLowerCase() !== 'cf-ray' && key.toLowerCase() !== 'cf-connecting-ip') {
+        headers.set(key, value);
+      }
+    }
+    
+    const response = await fetch(GOOGLE_APPS_SCRIPT_URL, {
+      method: 'POST',
+      headers,
+      body,
+      redirect: 'follow'
+    });
+    
+    const responseBody = await response.text();
+    
+    return new Response(responseBody, {
+      status: response.status,
+      headers: {
+        'Content-Type': response.headers.get('content-type') || 'text/plain',
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+      }
+    });
+    
+  } catch (error) {
+    console.error('Error proxying to Google Apps Script:', error);
+    return new Response('Internal server error', { status: 500 });
+  }
+}
+
+export async function OPTIONS({ request }: { request: Request }) {
+  return new Response(null, {
+    status: 200,
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization'
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add Cloudflare Workers endpoint at `/workers/toggl-asana-sync` that proxies to Google Apps Script
- expose `TOGGL_ASANA_SCRIPT_URL` in environment typings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876782114088327816168379e0d557e